### PR TITLE
fix: normaliza a ordenação de opcionais e ajusta a chave de agrupamen…

### DIFF
--- a/src/app/api/cron/food_orders/route.ts
+++ b/src/app/api/cron/food_orders/route.ts
@@ -65,7 +65,14 @@ export async function GET() {
           const pedidosAgrupados: GroupedEmailOrder[] = orders.map((order, idx) => {
             const fullName = `${order.user.firstName} ${order.user?.lastName ?? ""}`.trim();
             const prato = order.menuItem?.name ?? "";
+            // Ordena por nome da opção e depois nome da escolha para garantir consistência
             const opcionais = (order.optionSelections ?? [])
+              .slice()
+              .sort((a, b) => {
+                const optCmp = a.choice.option.name.localeCompare(b.choice.option.name, "pt-BR", { sensitivity: "base" });
+                if (optCmp !== 0) return optCmp;
+                return a.choice.name.localeCompare(b.choice.name, "pt-BR", { sensitivity: "base" });
+              })
               .map((sel) => `${sel.choice.option.name}: ${sel.choice.name}`)
               .filter(Boolean);
             const opc = opcionais.length > 0 ? opcionais.join(", ") : ""; // vazio => "sem adicional"

--- a/src/lib/mail/html-mock.ts
+++ b/src/lib/mail/html-mock.ts
@@ -495,7 +495,16 @@ export type GroupedEmailOrder = {
   
   function getGroupKey(p: GroupedEmailOrder) {
     const opc = (p.opc ?? "").trim();
-    return opc ? `${p.prato} com ${opc}` : `${p.prato} sem adicional`;
+    if (!opc) return `${p.prato} sem adicional`;
+    // Normaliza a string de opcionais para evitar diferenças de ordem
+    // Ex.: "Feijão: Sim, Salada: Não" e "Salada: Não, Feijão: Sim" viram a mesma chave
+    const normalized = opc
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b, "pt-BR", { sensitivity: "base" }))
+      .join(", ");
+    return `${p.prato} com ${normalized}`;
   }
   
   function groupPedidosByPratoOpc(pedidos: GroupedEmailOrder[]) {


### PR DESCRIPTION
…to para pedidos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional items are now displayed in a consistent alphabetical order (pt-BR collation) for clearer, predictable summaries.
  * Orders with the same set of optional items are correctly grouped together, regardless of selection order, reducing duplicate groups in emails and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->