### PR TITLE
feat: vínculo Empresa+Filial e DRE detalhado por empresa

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elo",
-  "version": "1.29.1",
+  "version": "1.32.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/sql/backfill-cristallux-filial-users.sql
+++ b/scripts/sql/backfill-cristallux-filial-users.sql
@@ -1,0 +1,24 @@
+-- Backfill: vincula colaboradores com enterprise = 'Cristallux_Filial'
+-- à filial de id 'cmpxzjlta000gjk04dvipce45'.
+--
+-- Observações de segurança:
+--  * O UPDATE só roda se a filial alvo existir (evita violação de FK e
+--    atualização indevida caso o id não exista neste banco).
+--  * "updatedAt" é setado manualmente porque o @updatedAt do Prisma é
+--    aplicado na camada da aplicação, não em UPDATEs via SQL puro.
+--  * Não altera o campo "enterprise" — apenas preenche "filialId".
+
+-- 1) (Opcional) Conferência antes de aplicar — quantos serão afetados:
+-- SELECT COUNT(*) AS users_a_atualizar
+-- FROM "users"
+-- WHERE "enterprise" = 'Cristallux_Filial'
+--   AND ("filialId" IS DISTINCT FROM 'cmpxzjlta000gjk04dvipce45');
+
+-- 2) Aplicação do backfill:
+UPDATE "users"
+SET "filialId"  = 'cmpxzjlta000gjk04dvipce45',
+    "updatedAt" = NOW()
+WHERE "enterprise" = 'Cristallux_Filial'
+  AND EXISTS (
+    SELECT 1 FROM "filiais" WHERE "id" = 'cmpxzjlta000gjk04dvipce45'
+  );

--- a/src/app/(authenticated)/admin/food/_components/dre-report.tsx
+++ b/src/app/(authenticated)/admin/food/_components/dre-report.tsx
@@ -13,7 +13,7 @@ import { DateRangeCalendar } from "@/components/forms/date-range-calendar"
 import { toast } from "sonner"
 import { format, startOfMonth, endOfMonth } from "date-fns"
 import { ptBR } from "date-fns/locale"
-import { Calculator, FileText, Eye, FileSpreadsheet } from "lucide-react"
+import { Calculator, FileText, Eye, FileSpreadsheet, ChevronDown, ChevronRight, ExternalLink } from "lucide-react"
 import * as XLSX from "xlsx"
 import {
   Dialog,
@@ -32,6 +32,8 @@ type DreGroupBy = "enterprise_sector" | "restaurant" | "filial"
 interface DREApiItem {
   groupBy: DreGroupBy
   enterprise: string | null
+  empresaId: string | null
+  empresaName: string | null
   sector: string | null
   restaurantId: string | null
   restaurantName: string | null
@@ -52,6 +54,8 @@ interface DREData extends DREApiItem {
 interface DREReportProps {
   selectedDate: Date
   setSelectedDate: (date: Date) => void
+  /** Navega para a aba de Pedidos já filtrada por data e e-mail do colaborador. */
+  onOpenOrder?: (params: { date: Date; email: string }) => void
 }
 
 const BRANCH_ENTERPRISES = ["Box_Filial", "Cristallux_Filial"] as const
@@ -63,7 +67,17 @@ function getEnterpriseType(enterprise: string | null): "headquarters" | "branch"
     : "headquarters"
 }
 
-export default function DREReport({ selectedDate }: DREReportProps) {
+// Identidade da Empresa (cadastro novo) para agrupar/comparar linhas do DRE.
+function empresaKey(item: { empresaId: string | null; enterprise: string | null }): string {
+  return item.empresaId ?? `enum:${item.enterprise ?? ""}`
+}
+
+// Rótulo de exibição da Empresa: nome do cadastro novo, com fallback no enum legado.
+function empresaLabel(item: { empresaName: string | null; enterprise: string | null }): string {
+  return item.empresaName ?? item.enterprise ?? "Não informado"
+}
+
+export default function DREReport({ selectedDate, onOpenOrder }: DREReportProps) {
   const [invoiceValue, setInvoiceValue] = useState<string>("")
   const [startDate, setStartDate] = useState<Date | undefined>(startOfMonth(selectedDate))
   const [endDate, setEndDate] = useState<Date | undefined>(endOfMonth(selectedDate))
@@ -73,6 +87,12 @@ export default function DREReport({ selectedDate }: DREReportProps) {
   const [filterFilialId, setFilterFilialId] = useState<string>(FILTER_ALL)
   const [filterEmpresaId, setFilterEmpresaId] = useState<string>(FILTER_ALL)
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false)
+  const [expandedGroup, setExpandedGroup] = useState<{
+    empresaId: string | null
+    empresaName: string | null
+    enterprise: string | null
+    sector: string | null
+  } | null>(null)
 
   const selectedYear = startDate?.getFullYear() ?? new Date().getFullYear()
 
@@ -97,6 +117,31 @@ export default function DREReport({ selectedDate }: DREReportProps) {
       retry: false,
     },
   )
+
+  const detailQuery = api.foodOrder.getEnterpriseSectorOrders.useQuery(
+    {
+      year: selectedYear,
+      period: "month",
+      date: startDate,
+      startDate: startDate,
+      endDate: endDate,
+      restaurantId: filterRestaurantId === FILTER_ALL ? undefined : filterRestaurantId,
+      filialId: filterFilialId === FILTER_ALL ? undefined : filterFilialId,
+      // Identidade do grupo (empresa do cadastro novo) da linha expandida.
+      empresaId: expandedGroup?.empresaId ?? undefined,
+      enterprise: expandedGroup?.enterprise ?? "",
+      sector: expandedGroup?.sector ?? null,
+    },
+    {
+      enabled: !!(expandedGroup && startDate && endDate),
+      retry: false,
+    },
+  )
+
+  // Fecha a linha expandida quando os filtros/período do relatório mudam
+  useEffect(() => {
+    setExpandedGroup(null)
+  }, [startDate, endDate, groupBy, filterRestaurantId, filterFilialId, filterEmpresaId])
 
   useEffect(() => {
     const err = dreQuery.error
@@ -128,8 +173,9 @@ export default function DREReport({ selectedDate }: DREReportProps) {
 
       if (item.groupBy === "enterprise_sector") {
         if (rateioType === "proportional") {
+          const itemEmpresaKey = empresaKey(item)
           const enterpriseTotal =
-            raw.filter((d) => d.enterprise === item.enterprise).reduce((s, d) => s + d.totalValue, 0) ?? 0
+            raw.filter((d) => empresaKey(d) === itemEmpresaKey).reduce((s, d) => s + d.totalValue, 0) ?? 0
 
           const globalTotal = globalTotalAllRows
 
@@ -231,7 +277,7 @@ export default function DREReport({ selectedDate }: DREReportProps) {
 
       if (item.groupBy === "enterprise_sector") {
         return {
-          Empresa: item.enterprise ?? "",
+          Empresa: empresaLabel(item),
           Setor: item.sector ?? "Não informado",
           ...base,
         }
@@ -559,6 +605,7 @@ export default function DREReport({ selectedDate }: DREReportProps) {
                   <TableRow>
                     {groupBy === "enterprise_sector" ? (
                       <>
+                        <TableHead className="w-8" />
                         <TableHead>Empresa</TableHead>
                         <TableHead>Setor</TableHead>
                       </>
@@ -577,41 +624,145 @@ export default function DREReport({ selectedDate }: DREReportProps) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {filteredData.map((item, index) => (
-                    <TableRow
-                      key={
-                        groupBy === "enterprise_sector"
-                          ? `${item.enterprise}-${item.sector}-${index}`
-                          : groupBy === "restaurant"
-                            ? `${item.restaurantId ?? "nr"}-${index}`
-                            : `${item.filialId ?? "nf"}-${index}`
-                      }
-                    >
-                      {groupBy === "enterprise_sector" ? (
-                        <>
-                          <TableCell>
-                            <Badge variant="outline">{item.enterprise}</Badge>
+                  {filteredData.map((item, index) => {
+                    const isEnterpriseSector = groupBy === "enterprise_sector"
+                    const rowKey = isEnterpriseSector
+                      ? `${empresaKey(item)}-${item.sector}-${index}`
+                      : groupBy === "restaurant"
+                        ? `${item.restaurantId ?? "nr"}-${index}`
+                        : `${item.filialId ?? "nf"}-${index}`
+                    const isExpanded =
+                      isEnterpriseSector &&
+                      expandedGroup != null &&
+                      empresaKey(expandedGroup) === empresaKey(item) &&
+                      expandedGroup.sector === item.sector
+
+                    return (
+                      <React.Fragment key={rowKey}>
+                        <TableRow
+                          className={isEnterpriseSector ? "cursor-pointer" : undefined}
+                          onClick={
+                            isEnterpriseSector
+                              ? () =>
+                                  setExpandedGroup((prev) =>
+                                    prev != null &&
+                                    empresaKey(prev) === empresaKey(item) &&
+                                    prev.sector === item.sector
+                                      ? null
+                                      : {
+                                          empresaId: item.empresaId,
+                                          empresaName: item.empresaName,
+                                          enterprise: item.enterprise,
+                                          sector: item.sector,
+                                        },
+                                  )
+                              : undefined
+                          }
+                        >
+                          {isEnterpriseSector ? (
+                            <>
+                              <TableCell className="w-8 pr-0">
+                                {isExpanded ? (
+                                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                                )}
+                              </TableCell>
+                              <TableCell>
+                                <Badge variant="outline">{empresaLabel(item)}</Badge>
+                              </TableCell>
+                              <TableCell>{item.sector ?? "Não informado"}</TableCell>
+                            </>
+                          ) : null}
+                          {groupBy === "restaurant" ? (
+                            <TableCell>{item.restaurantName ?? "Não informado"}</TableCell>
+                          ) : null}
+                          {groupBy === "filial" ? (
+                            <>
+                              <TableCell>{item.filialName ?? "Não informado"}</TableCell>
+                              <TableCell>{item.filialCode ?? "—"}</TableCell>
+                            </>
+                          ) : null}
+                          <TableCell className="text-right">{item.totalOrders}</TableCell>
+                          <TableCell className="text-right">R$ {item.totalValue.toFixed(2)}</TableCell>
+                          <TableCell className="text-right">{item.representativeness.toFixed(2)}%</TableCell>
+                          <TableCell className="text-right">
+                            R$ {item.costCenterRateio?.toFixed(2) ?? "0.00"}
                           </TableCell>
-                          <TableCell>{item.sector ?? "Não informado"}</TableCell>
-                        </>
-                      ) : null}
-                      {groupBy === "restaurant" ? (
-                        <TableCell>{item.restaurantName ?? "Não informado"}</TableCell>
-                      ) : null}
-                      {groupBy === "filial" ? (
-                        <>
-                          <TableCell>{item.filialName ?? "Não informado"}</TableCell>
-                          <TableCell>{item.filialCode ?? "—"}</TableCell>
-                        </>
-                      ) : null}
-                      <TableCell className="text-right">{item.totalOrders}</TableCell>
-                      <TableCell className="text-right">R$ {item.totalValue.toFixed(2)}</TableCell>
-                      <TableCell className="text-right">{item.representativeness.toFixed(2)}%</TableCell>
-                      <TableCell className="text-right">
-                        R$ {item.costCenterRateio?.toFixed(2) ?? "0.00"}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                        </TableRow>
+
+                        {isExpanded ? (
+                          <TableRow className="hover:bg-transparent">
+                            <TableCell colSpan={7} className="bg-muted/30 p-0">
+                              <div className="p-3">
+                                {detailQuery.isLoading ? (
+                                  <p className="py-2 text-sm text-muted-foreground">Carregando pedidos...</p>
+                                ) : detailQuery.isError ? (
+                                  <p className="py-2 text-sm text-muted-foreground">
+                                    Erro ao carregar os pedidos deste grupo.
+                                  </p>
+                                ) : detailQuery.data && detailQuery.data.length > 0 ? (
+                                  <Table>
+                                    <TableHeader>
+                                      <TableRow>
+                                        <TableHead>Pessoa</TableHead>
+                                        <TableHead>Empresa</TableHead>
+                                        <TableHead>Setor</TableHead>
+                                        <TableHead>Data do pedido</TableHead>
+                                        <TableHead>Prato</TableHead>
+                                        <TableHead className="text-right">Valor (R$)</TableHead>
+                                        <TableHead className="text-right">Pedido</TableHead>
+                                      </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                      {detailQuery.data.map((order) => (
+                                        <TableRow key={order.id}>
+                                          <TableCell>
+                                            <div className="font-medium">{order.userName || "—"}</div>
+                                            <div className="text-xs text-muted-foreground">{order.email}</div>
+                                          </TableCell>
+                                          <TableCell>
+                                            <Badge variant="outline">{order.empresaName ?? order.enterprise}</Badge>
+                                          </TableCell>
+                                          <TableCell>{order.sector ?? "Não informado"}</TableCell>
+                                          <TableCell>
+                                            {format(new Date(order.orderDate), "dd/MM/yyyy", { locale: ptBR })}
+                                          </TableCell>
+                                          <TableCell>{order.menuItemName}</TableCell>
+                                          <TableCell className="text-right">R$ {order.price.toFixed(2)}</TableCell>
+                                          <TableCell className="text-right">
+                                            <Button
+                                              variant="outline"
+                                              size="sm"
+                                              className="flex items-center gap-1"
+                                              onClick={(e) => {
+                                                e.stopPropagation()
+                                                onOpenOrder?.({
+                                                  date: new Date(order.orderDate),
+                                                  email: order.email,
+                                                })
+                                              }}
+                                            >
+                                              <ExternalLink className="h-3.5 w-3.5" />
+                                              Ir para o pedido
+                                            </Button>
+                                          </TableCell>
+                                        </TableRow>
+                                      ))}
+                                    </TableBody>
+                                  </Table>
+                                ) : (
+                                  <p className="py-2 text-sm text-muted-foreground">
+                                    Nenhum pedido encontrado para este grupo.
+                                  </p>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ) : null}
+                      </React.Fragment>
+                    )
+                  })}
                 </TableBody>
               </Table>
 
@@ -720,7 +871,7 @@ export default function DREReport({ selectedDate }: DREReportProps) {
                         <TableRow
                           key={
                             groupBy === "enterprise_sector"
-                              ? `m-${item.enterprise}-${item.sector}-${index}`
+                              ? `m-${empresaKey(item)}-${item.sector}-${index}`
                               : groupBy === "restaurant"
                                 ? `m-${item.restaurantId ?? "nr"}-${index}`
                                 : `m-${item.filialId ?? "nf"}-${index}`
@@ -729,7 +880,7 @@ export default function DREReport({ selectedDate }: DREReportProps) {
                           {groupBy === "enterprise_sector" ? (
                             <>
                               <TableCell>
-                                <Badge variant="outline">{item.enterprise}</Badge>
+                                <Badge variant="outline">{empresaLabel(item)}</Badge>
                               </TableCell>
                               <TableCell>{item.sector ?? "Não informado"}</TableCell>
                             </>

--- a/src/app/(authenticated)/admin/food/_components/orders-tab.tsx
+++ b/src/app/(authenticated)/admin/food/_components/orders-tab.tsx
@@ -33,6 +33,8 @@ interface OrdersTabProps {
   setSelectedStatus: (status: string) => void
   userName: string
   setUserName: (name: string) => void
+  userEmail: string
+  setUserEmail: (email: string) => void
   onStatsChange?: (s: { total: number; pending: number; confirmed: number; delivered: number }) => void
 }
 
@@ -45,6 +47,8 @@ export default function OrdersTab({
   setSelectedStatus,
   userName,
   setUserName,
+  userEmail,
+  setUserEmail,
   onStatsChange
 }: OrdersTabProps) {
   const FILIAL_ALL = "__all__"
@@ -121,6 +125,7 @@ export default function OrdersTab({
     restaurantId: selectedRestaurant || undefined,
     status: selectedStatus ? (selectedStatus as "PENDING" | "CONFIRMED" | "DELIVERED" | "CANCELLED") : undefined,
     userName: userName || undefined,
+    userEmail: userEmail || undefined,
     filialId: selectedFilial !== FILIAL_ALL ? selectedFilial : undefined,
     page,
     pageSize: PAGE_SIZE,
@@ -135,7 +140,7 @@ export default function OrdersTab({
   // Resetar página quando filtros mudam
   useEffect(() => {
     setPage(1)
-  }, [selectedDate, selectedRestaurant, selectedStatus, userName, selectedFilial])
+  }, [selectedDate, selectedRestaurant, selectedStatus, userName, userEmail, selectedFilial])
 
   // Reportar estatísticas para a página usando contagens do servidor (todos os resultados, não só a página)
   useEffect(() => {
@@ -784,7 +789,7 @@ export default function OrdersTab({
           <CardTitle>Filtros</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <div className="flex items-center space-x-2">
               <Label>Data</Label>
               <DatePicker
@@ -842,7 +847,15 @@ export default function OrdersTab({
               <Input
                 value={userName}
                 onChange={(e) => setUserName(e.target.value)}
-                placeholder="Buscar por nome ou email..."
+                placeholder="Buscar por nome..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>E-mail do Colaborador</Label>
+              <Input
+                value={userEmail}
+                onChange={(e) => setUserEmail(e.target.value)}
+                placeholder="Buscar por e-mail..."
               />
             </div>
           </div>
@@ -872,6 +885,9 @@ export default function OrdersTab({
               }
               if (userName) {
                 filters.push(`Nome: ${userName}`)
+              }
+              if (userEmail) {
+                filters.push(`E-mail: ${userEmail}`)
               }
 
               return filters.length > 0 ? filters.join(" | ") : "Todos os pedidos da data selecionada"

--- a/src/app/(authenticated)/admin/food/page.tsx
+++ b/src/app/(authenticated)/admin/food/page.tsx
@@ -24,7 +24,19 @@ export default function AdminFoodPage() {
   const [selectedRestaurant, setSelectedRestaurant] = useState<string>("")
   const [selectedStatus, setSelectedStatus] = useState<string>("")
   const [userName, setUserName] = useState<string>("")
+  const [userEmail, setUserEmail] = useState<string>("")
+  const [activeTab, setActiveTab] = useState<string>("orders")
   const [stats, setStats] = useState({ total: 0, pending: 0, confirmed: 0, delivered: 0 })
+
+  // Vindo do relatório DRE: abre a aba de Pedidos já filtrada pela data e e-mail do colaborador
+  const handleOpenOrderFromDre = ({ date, email }: { date: Date; email: string }) => {
+    setSelectedDate(date)
+    setUserEmail(email)
+    setUserName("")
+    setSelectedRestaurant("")
+    setSelectedStatus("")
+    setActiveTab("orders")
+  }
   
   // Verificar acesso ao módulo de comida
   if (!isLoading && !hasAdminAccess("/admin/food")) {
@@ -79,7 +91,7 @@ export default function AdminFoodPage() {
         </Card>
       </div>
 
-      <Tabs defaultValue="orders" className="space-y-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <TabsList>
           <TabsTrigger value="orders">Pedidos</TabsTrigger>
           <TabsTrigger value="restaurants">Restaurantes</TabsTrigger>
@@ -100,6 +112,8 @@ export default function AdminFoodPage() {
             setSelectedStatus={setSelectedStatus}
             userName={userName}
             setUserName={setUserName}
+            userEmail={userEmail}
+            setUserEmail={setUserEmail}
             onStatsChange={setStats}
           />
         </TabsContent>
@@ -125,6 +139,7 @@ export default function AdminFoodPage() {
               <DREReport
                 selectedDate={selectedDate}
                 setSelectedDate={setSelectedDate}
+                onOpenOrder={handleOpenOrderFromDre}
               />
             </TabsContent>
           )}

--- a/src/app/(authenticated)/admin/users/page.tsx
+++ b/src/app/(authenticated)/admin/users/page.tsx
@@ -111,9 +111,18 @@ export default function UsersManagementPage() {
   })
 
   const { data: allForms } = api.form.list.useQuery()
+  const { data: empresas = [] } = api.empresas.list.useQuery()
   const { data: filiaisRaw = [] } = api.filiais.list.useQuery()
   const filiais = useMemo(
-    () => filiaisRaw.map((f) => ({ id: f.id, name: f.name, code: f.code, enterprise: f.empresa.enterprise })),
+    () =>
+      filiaisRaw.map((f) => ({
+        id: f.id,
+        name: f.name,
+        code: f.code,
+        enterprise: f.empresa.enterprise,
+        empresaId: f.empresa.id,
+        empresaName: f.empresa.name,
+      })),
     [filiaisRaw],
   )
 
@@ -307,6 +316,7 @@ export default function UsersManagementPage() {
                       }}
                       allForms={allForms ?? []}
                       filiais={filiais}
+                      empresas={empresas}
                       onUserUpdate={() => refetch()}
                     />
                   ))}
@@ -378,7 +388,8 @@ interface UserManagementCardProps {
     lojinha_phone?: string | null
   }
   allForms: { id: string; title: string }[]
-  filiais?: { id: string; name: string; code: string; enterprise: Enterprise }[]
+  filiais?: { id: string; name: string; code: string; enterprise: Enterprise; empresaId: string; empresaName: string }[]
+  empresas?: { id: string; name: string }[]
   onUserUpdate: () => void
 }
 
@@ -410,7 +421,7 @@ function extendedRoleConfigFromServer(role: RolesConfig | null | undefined): Ext
   }
 }
 
-function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: UserManagementCardProps) {
+function UserManagementCard({ user, allForms, filiais = [], empresas = [], onUserUpdate }: UserManagementCardProps) {
   const [activeTab, setActiveTab] = useState("basic")
   const [isEditing, setIsEditing] = useState(false)
   const [permissionSearch, setPermissionSearch] = useState("")
@@ -445,19 +456,28 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
     emailExtension: user.emailExtension ?? "",
     matricula: user.matricula ?? "",
     email_empresarial: user.email_empresarial ?? "",
-    enterprise: user.enterprise ?? "NA",
     is_active: (user as { is_active?: boolean }).is_active ?? true,
   })
-  const [isEditingFilial, setIsEditingFilial] = useState(false)
-  const [selectedUserFilial, setSelectedUserFilial] = useState<string>(user.filialId ?? "")
+  // Modelo novo: o vínculo é feito por Empresa + Filial (salva-se filialId; o enum
+  // enterprise é derivado no servidor a partir de filial.empresa).
+  const [empresaId, setEmpresaId] = useState<string>("")
+  const [basicFilialId, setBasicFilialId] = useState<string>(user.filialId ?? "")
 
-  const userEnterpriseRequiresFilial =
-    user.enterprise === "Box_Filial" || user.enterprise === "Cristallux_Filial"
+  // Sincroniza empresa/filial do formulário com a filial atual do usuário
+  useEffect(() => {
+    const current = filiais.find((f) => f.id === user.filialId)
+    setEmpresaId(current?.empresaId ?? "")
+    setBasicFilialId(user.filialId ?? "")
+  }, [user.filialId, filiais])
 
-  const filiaisForUserEnterprise = useMemo(() => {
-    if (!userEnterpriseRequiresFilial) return []
-    return (filiais ?? []).filter((f) => f.enterprise === user.enterprise)
-  }, [filiais, user.enterprise, userEnterpriseRequiresFilial])
+  const filiaisForEmpresa = useMemo(
+    () => filiais.filter((f) => f.empresaId === empresaId),
+    [filiais, empresaId],
+  )
+  const currentEmpresaName = useMemo(
+    () => filiais.find((f) => f.id === user.filialId)?.empresaName,
+    [filiais, user.filialId],
+  )
   const [permissionsData, setPermissionsData] = useState<ExtendedRolesConfig>(() =>
     extendedRoleConfigFromServer(user.role_config),
   )
@@ -627,25 +647,6 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
     },
   })
 
-  const updateUserFilial = api.user.updateUserFilial.useMutation({
-    onSuccess: async () => {
-      toast({
-        title: "Filial atualizada",
-        description: "A filial do usuário foi atualizada com sucesso.",
-      })
-      setIsEditingFilial(false)
-      await utils.user.listUsers.invalidate()
-      onUserUpdate()
-    },
-    onError: (error) => {
-      toast({
-        title: "Erro",
-        description: error.message,
-        variant: "destructive",
-      })
-    },
-  })
-
   const toggleActive = api.user.updateBasicInfo.useMutation({
     onSuccess: async () => {
       const nowActive = user.is_active === false
@@ -696,6 +697,14 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
   }
 
   const handleSaveBasicInfo = () => {
+    if (empresaId && !basicFilialId) {
+      toast({
+        title: "Campo obrigatório",
+        description: "Selecione a filial da empresa.",
+        variant: "destructive",
+      })
+      return
+    }
     updateBasicInfo.mutate({
       userId: user.id,
       ...basicData,
@@ -704,8 +713,8 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
       emailExtension: basicData.emailExtension || "",
       matricula: basicData.matricula || "",
       email_empresarial: basicData.email_empresarial || "",
-      enterprise: basicData.enterprise,
       is_active: basicData.is_active,
+      filialId: basicFilialId || null,
     })
   }
 
@@ -827,13 +836,6 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
         })
       }
     }
-  }
-
-  const handleSaveUserFilial = () => {
-    updateUserFilial.mutate({
-      userId: user.id,
-      filialId: selectedUserFilial || null,
-    })
   }
 
   const isUserActive = user.is_active !== false
@@ -1024,18 +1026,40 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
                     </Select>
                   </div>
                   <div>
-                    <Label htmlFor="enterprise">Empresa</Label>
+                    <Label htmlFor="empresa">Empresa</Label>
                     <Select
-                      value={basicData.enterprise}
-                      onValueChange={(value) => setBasicData({ ...basicData, enterprise: value as Enterprise })}
+                      value={empresaId}
+                      onValueChange={(value) => {
+                        setEmpresaId(value)
+                        setBasicFilialId("")
+                      }}
                     >
-                      <SelectTrigger id="enterprise">
+                      <SelectTrigger id="empresa">
                         <SelectValue placeholder="Selecione uma empresa" />
                       </SelectTrigger>
                       <SelectContent>
-                        {ENTERPRISE_OPTIONS.filter((opt) => opt.value !== "all").map((opt) => (
-                          <SelectItem key={opt.value} value={opt.value}>
-                            {opt.label}
+                        {empresas.map((emp) => (
+                          <SelectItem key={emp.id} value={emp.id}>
+                            {emp.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="filial">Filial</Label>
+                    <Select
+                      value={basicFilialId}
+                      onValueChange={setBasicFilialId}
+                      disabled={!empresaId}
+                    >
+                      <SelectTrigger id="filial">
+                        <SelectValue placeholder={empresaId ? "Selecione uma filial" : "Selecione a empresa primeiro"} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {filiaisForEmpresa.map((f) => (
+                          <SelectItem key={f.id} value={f.id}>
+                            {f.name} ({f.code})
                           </SelectItem>
                         ))}
                       </SelectContent>
@@ -1143,7 +1167,7 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
                 </div>
                 <div>
                   <Label className="text-xs text-muted-foreground">Empresa</Label>
-                  <p className="text-sm font-medium">{getEnterpriseLabel(user.enterprise)}</p>
+                  <p className="text-sm font-medium">{currentEmpresaName ?? getEnterpriseLabel(user.enterprise)}</p>
                 </div>
                 <div>
                   <Label className="text-xs text-muted-foreground">Ramal</Label>
@@ -1178,12 +1202,6 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
                     <Edit3 className="h-4 w-4 mr-2" />
                     Editar Dados
                   </Button>
-                  {userEnterpriseRequiresFilial ? (
-                    <Button onClick={() => setIsEditingFilial(true)} size="sm" variant="outline">
-                      <Edit3 className="h-4 w-4 mr-2" />
-                      Alterar Filial
-                    </Button>
-                  ) : null}
                 </div>
               </div>
             )}
@@ -2022,63 +2040,6 @@ function UserManagementCard({ user, allForms, filiais = [], onUserUpdate }: User
             </TabsContent>
           )}
         </Tabs>
-
-        {/* Dialog: Editar Filial */}
-        <Dialog open={isEditingFilial} onOpenChange={setIsEditingFilial}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Alterar Filial do Usuário</DialogTitle>
-              <DialogDescription>
-                {user.firstName} {user.lastName}
-              </DialogDescription>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div>
-                <Label htmlFor="filial-select">Filial</Label>
-                <Select
-                  value={selectedUserFilial || "none"}
-                  onValueChange={(value) => setSelectedUserFilial(value === "none" ? "" : value)}
-                >
-                  <SelectTrigger id="filial-select">
-                    <SelectValue placeholder="Selecione uma filial" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">Sem filial</SelectItem>
-                    {filiaisForUserEnterprise.map((f) => (
-                      <SelectItem key={f.id} value={f.id}>
-                        {f.name} ({f.code})
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setIsEditingFilial(false)
-                  setSelectedUserFilial(user.filialId ?? "")
-                }}
-              >
-                Cancelar
-              </Button>
-              <Button
-                onClick={handleSaveUserFilial}
-                disabled={updateUserFilial.isPending}
-              >
-                {updateUserFilial.isPending ? (
-                  <>
-                    <span className="animate-spin mr-2">⏳</span>
-                    Salvando...
-                  </>
-                ) : (
-                  "Salvar"
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
       </CardContent>
     </Card>
     </>

--- a/src/components/ui/complete-profile-modal.tsx
+++ b/src/components/ui/complete-profile-modal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -9,7 +9,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { api } from "@/trpc/react"
 import { useToast } from "@/hooks/use-toast"
 import { Loader2 } from "lucide-react"
-import type { Enterprise } from "@/types/enterprise"
 
 interface CompleteProfileModalProps {
   isOpen: boolean
@@ -24,23 +23,8 @@ interface CompleteProfileModalProps {
   onClose?: () => void
 }
 
-type FilialOption = {
-  id: string
-  name: string
-  code: string
-  enterprise: Enterprise
-}
-
-const enterprises = [
-  { value: "Box", label: "Box" },
-  { value: "Box_Filial", label: "Box Filial" },
-  { value: "Cristallux", label: "Cristallux" },
-  { value: "Cristallux_Filial", label: "Cristallux Filial" },
-]
-
 const setores = [
   { value: "ADMINISTRATIVO", label: "Administrativo" },
-  { value: "COMERCIAL", label: "Comercial" },
   { value: "COMERCIAL", label: "Comercial" },
   { value: "FINANCEIRO", label: "Financeiro" },
   { value: "RECURSOS_HUMANOS", label: "Recursos Humanos" },
@@ -53,47 +37,43 @@ const setores = [
 
 export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: CompleteProfileModalProps) {
   const [matricula, setMatricula] = useState("")
-  const [enterprise, setEnterprise] = useState("")
+  const [empresaId, setEmpresaId] = useState("")
   const [setor, setSetor] = useState("")
   const [filialId, setFilialId] = useState("")
   const [isLoading, setIsLoading] = useState(false)
 
   const { toast } = useToast()
-  const shouldRequireFilial = enterprise === "Box_Filial" || enterprise === "Cristallux_Filial"
 
-  const { data: filiaisData = [] } = api.filiais.list.useQuery(undefined, {
-    enabled: shouldRequireFilial && !!enterprise,
-  })
-  const filiais: FilialOption[] = filiaisData.map((f) => ({
-    id: f.id,
-    name: f.name,
-    code: f.code,
-    enterprise: f.empresa.enterprise,
-  }))
+  const { data: empresas = [] } = api.empresas.list.useQuery(undefined, { enabled: isOpen })
+  const { data: filiaisData = [] } = api.filiais.list.useQuery(undefined, { enabled: isOpen })
 
-  // Atualizar os valores quando o modal abrir
+  // Filiais da empresa selecionada
+  const filiais = useMemo(
+    () => filiaisData.filter((f) => f.empresa.id === empresaId),
+    [filiaisData, empresaId],
+  )
+
+  // Atualizar os valores quando o modal abrir (pré-preenche empresa pela filial atual, se houver)
   useEffect(() => {
     if (isOpen && user) {
       setMatricula(user.matricula ?? "")
-      setEnterprise(user.enterprise ?? "")
       setSetor(user.setor ?? "")
       setFilialId(user.filialId ?? "")
+      const currentFilial = user.filialId
+        ? filiaisData.find((f) => f.id === user.filialId)
+        : undefined
+      setEmpresaId(currentFilial?.empresa.id ?? "")
     }
-  }, [isOpen, user])
+  }, [isOpen, user, filiaisData])
 
+  // Ao trocar de empresa, limpar a filial que não pertence mais à empresa selecionada
   useEffect(() => {
-    if (!shouldRequireFilial && filialId) {
-      setFilialId("")
-    }
-  }, [shouldRequireFilial, filialId])
-
-  useEffect(() => {
-    if (!shouldRequireFilial || !filialId) return
+    if (!filialId) return
     const allowed = new Set(filiais.map((f) => f.id))
     if (!allowed.has(filialId)) {
       setFilialId("")
     }
-  }, [shouldRequireFilial, filiais, filialId])
+  }, [filiais, filialId])
 
   const updateProfileMutation = api.user.updateProfile.useMutation({
     onSuccess: () => {
@@ -128,7 +108,7 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
       return
     }
 
-    if (!enterprise.trim()) {
+    if (!empresaId) {
       toast({
         title: "Campo obrigatório",
         description: "Por favor, selecione sua empresa.",
@@ -145,7 +125,8 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
       })
       return
     }
-    if (shouldRequireFilial && !filialId.trim()) {
+
+    if (!filialId.trim()) {
       toast({
         title: "Campo obrigatório",
         description: "Por favor, selecione sua filial.",
@@ -158,9 +139,8 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
 
     updateProfileMutation.mutate({
       matricula: matricula.trim(),
-      enterprise: enterprise.trim() as Enterprise,
       setor: setor.trim(),
-      filialId: shouldRequireFilial ? filialId.trim() : null,
+      filialId: filialId.trim(),
     })
   }
 
@@ -170,9 +150,7 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
         <DialogHeader>
           <DialogTitle>Perfil Obrigatório</DialogTitle>
           <DialogDescription>
-            Para continuar usando a plataforma, informe seu número de matrícula, empresa e setor.
-            <br />
-            Se a empresa selecionada for Box Filial ou Cristallux Filial, você também precisa escolher a filial.
+            Para continuar usando a plataforma, informe seu número de matrícula, empresa, filial e setor.
             <br />
             {`Se você trabalhar na modalidade PJ, pode anotar "Número da matrícula" como 0!`}
           </DialogDescription>
@@ -191,15 +169,37 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="enterprise">Empresa *</Label>
-            <Select value={enterprise} onValueChange={setEnterprise}>
+            <Label htmlFor="empresa">Empresa *</Label>
+            <Select
+              value={empresaId}
+              onValueChange={(v) => {
+                setEmpresaId(v)
+                setFilialId("")
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Selecione sua empresa" />
               </SelectTrigger>
               <SelectContent>
-                {enterprises.map((ent) => (
-                  <SelectItem key={ent.value} value={ent.value}>
-                    {ent.label}
+                {empresas.map((emp) => (
+                  <SelectItem key={emp.id} value={emp.id}>
+                    {emp.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="filial">Filial *</Label>
+            <Select value={filialId} onValueChange={setFilialId} disabled={!empresaId}>
+              <SelectTrigger>
+                <SelectValue placeholder={empresaId ? "Selecione sua filial" : "Selecione a empresa primeiro"} />
+              </SelectTrigger>
+              <SelectContent>
+                {filiais.map((filial) => (
+                  <SelectItem key={filial.id} value={filial.id}>
+                    {filial.name} ({filial.code})
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -213,31 +213,14 @@ export function CompleteProfileModal({ isOpen, user, onSuccess, onClose }: Compl
                 <SelectValue placeholder="Selecione seu setor" />
               </SelectTrigger>
               <SelectContent>
-                {setores.map((setor) => (
-                  <SelectItem key={setor.value} value={setor.value}>
-                    {setor.label}
+                {setores.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {s.label}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
-          {shouldRequireFilial ? (
-            <div className="space-y-2">
-              <Label htmlFor="filial">Filial *</Label>
-              <Select value={filialId} onValueChange={setFilialId}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Selecione sua filial" />
-                </SelectTrigger>
-                <SelectContent>
-                  {filiais.map((filial) => (
-                    <SelectItem key={filial.id} value={filial.id}>
-                      {filial.name} ({filial.code})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ) : null}
 
           <div className="flex justify-center pt-6">
             <Button

--- a/src/const/app-release-notes.ts
+++ b/src/const/app-release-notes.ts
@@ -3,7 +3,7 @@
  * Lista apenas marcos **major** (quando existirem) e **minors** com impacto de produto — sem patches.
  * `APP_CURRENT_VERSION` segue o package.json (MMP completo).
  */
-export const APP_CURRENT_VERSION = "1.29.0" as const;
+export const APP_CURRENT_VERSION = "1.32.0" as const;
 
 export interface AppReleaseNote {
   /** Versão semântica do marco (minor.0 ou major.0) */
@@ -19,6 +19,29 @@ export interface AppReleaseNote {
  * Incluir somente releases **major** ou **minor** com entrega visível ao usuário.
  */
 export const APP_RELEASE_NOTES: AppReleaseNote[] = [
+  {
+    version: "1.32.0",
+    date: "Junho de 2026",
+    items: [
+      "**DRE mostra a empresa de verdade**: o relatório de resultado passou a exibir o nome da empresa cadastrada (em vez da sigla antiga), deixando os agrupamentos mais claros.",
+      "**Busca por e-mail nos pedidos**: a lista de pedidos ganhou um campo dedicado para buscar pelo e-mail do colaborador, separado da busca por nome.",
+    ],
+  },
+  {
+    version: "1.31.0",
+    date: "Junho de 2026",
+    items: [
+      "**Empresa e filial juntas no cadastro**: ao completar o perfil e na tela de Usuários, agora você escolhe a empresa e, em seguida, a filial — o vínculo fica certinho automaticamente.",
+    ],
+  },
+  {
+    version: "1.30.0",
+    date: "Junho de 2026",
+    items: [
+      "**Relatório DRE mais detalhado**: no relatório de resultado por empresa e setor, agora é só clicar em uma linha para abrir a lista das pessoas daquele grupo — com o nome, a empresa, o setor e o valor de cada pedido.",
+      "**Vá direto ao pedido**: ao lado de cada pessoa há um botão que leva você direto para a aba de Pedidos já filtrada por aquela pessoa e data, facilitando achar o pedido exato.",
+    ],
+  },
   {
     version: "1.29.0",
     date: "Maio de 2026",

--- a/src/server/api/routers/food-order.ts
+++ b/src/server/api/routers/food-order.ts
@@ -7,6 +7,57 @@ import type { RolesConfig } from "@/types/role-config"
 import { sendFoodOrdersEmail } from "@/server/services/food-order-email"
 import { checkSelfServiceFoodOrderDate } from "@/lib/food-order-self-service-date"
 
+/**
+ * Resolve o intervalo [startDate, endDate] usado pelas consultas do relatório DRE.
+ * Quando startDate/endDate são informados diretamente, têm prioridade; caso contrário
+ * o período é derivado de year/period/date. Mantém o comportamento em UTC.
+ */
+function resolveDrePeriod({
+  year,
+  period,
+  date,
+  startDate,
+  endDate,
+}: {
+  year: number
+  period: "month" | "quarter" | "year"
+  date?: Date
+  startDate?: Date
+  endDate?: Date
+}): { startDate: Date; endDate: Date } {
+  if (startDate && endDate) {
+    return {
+      startDate: new Date(Date.UTC(startDate.getFullYear(), startDate.getMonth(), startDate.getDate(), 0, 0, 0, 0)),
+      endDate: new Date(Date.UTC(endDate.getFullYear(), endDate.getMonth(), endDate.getDate(), 23, 59, 59, 999)),
+    }
+  }
+  if (period === "year") {
+    return {
+      startDate: new Date(Date.UTC(year, 0, 1)),
+      endDate: new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)),
+    }
+  }
+  if (period === "quarter" && date) {
+    const quarter = Math.floor(date.getMonth() / 3)
+    const quarterStartMonth = quarter * 3
+    return {
+      startDate: new Date(Date.UTC(year, quarterStartMonth, 1)),
+      endDate: new Date(Date.UTC(year, quarterStartMonth + 3, 0, 23, 59, 59, 999)),
+    }
+  }
+  if (period === "month" && date) {
+    const month = date.getMonth()
+    return {
+      startDate: new Date(Date.UTC(year, month, 1)),
+      endDate: new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999)),
+    }
+  }
+  return {
+    startDate: new Date(Date.UTC(year, 0, 1)),
+    endDate: new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)),
+  }
+}
+
 export const foodOrderRouter = createTRPCRouter({
   // Criar um novo pedido
   create: protectedProcedure
@@ -410,6 +461,7 @@ export const foodOrderRouter = createTRPCRouter({
         restaurantId: z.string().optional(),
         userId: z.string().optional(),
         userName: z.string().optional(),
+        userEmail: z.string().optional(),
         filialId: z.string().optional(),
         page: z.number().int().min(1).default(1),
         pageSize: z.number().int().min(1).max(100).default(15),
@@ -440,6 +492,11 @@ export const foodOrderRouter = createTRPCRouter({
           { lastName: { contains: input.userName, mode: "insensitive" } },
           { email: { contains: input.userName, mode: "insensitive" } },
         ]
+      }
+
+      // Filtro dedicado por e-mail (ex.: navegação vinda do relatório DRE)
+      if (input?.userEmail) {
+        userFilter.email = { contains: input.userEmail, mode: "insensitive" }
       }
 
       if (input?.filialId) {
@@ -963,6 +1020,10 @@ export const foodOrderRouter = createTRPCRouter({
     .query(async ({ ctx, input }): Promise<{
       groupBy: "enterprise_sector" | "restaurant" | "filial"
       enterprise: string | null
+      /** Id da Empresa (cadastro novo) dona da filial do colaborador. Null para registros legados sem filial. */
+      empresaId: string | null
+      /** Nome da Empresa (cadastro novo) para exibição no agrupamento por empresa/setor. */
+      empresaName: string | null
       sector: string | null
       restaurantId: string | null
       restaurantName: string | null
@@ -1002,48 +1063,13 @@ export const foodOrderRouter = createTRPCRouter({
       } = input
 
       // Definir o período de busca baseado no tipo selecionado
-      let startDate: Date
-      let endDate: Date
-
-      // Se startDate e endDate foram fornecidos diretamente, usar esses valores
-      if (inputStartDate && inputEndDate) {
-        startDate = new Date(Date.UTC(
-          inputStartDate.getFullYear(),
-          inputStartDate.getMonth(),
-          inputStartDate.getDate(),
-          0,
-          0,
-          0,
-          0
-        ))
-        endDate = new Date(Date.UTC(
-          inputEndDate.getFullYear(),
-          inputEndDate.getMonth(),
-          inputEndDate.getDate(),
-          23,
-          59,
-          59,
-          999
-        ))
-      } else if (period === "year") {
-        startDate = new Date(Date.UTC(year, 0, 1)) // 1 de janeiro
-        endDate = new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999)) // 31 de dezembro
-      } else if (period === "quarter" && date) {
-        // Para trimestre: calcular trimestre baseado na data
-        const quarter = Math.floor(date.getMonth() / 3)
-        const quarterStartMonth = quarter * 3
-        startDate = new Date(Date.UTC(year, quarterStartMonth, 1))
-        endDate = new Date(Date.UTC(year, quarterStartMonth + 3, 0, 23, 59, 59, 999))
-      } else if (period === "month" && date) {
-        // Para período mensal específico
-        const month = date.getMonth()
-        startDate = new Date(Date.UTC(year, month, 1))
-        endDate = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999))
-      } else {
-        // Fallback: buscar dados de todos os meses do ano
-        startDate = new Date(Date.UTC(year, 0, 1))
-        endDate = new Date(Date.UTC(year, 11, 31, 23, 59, 59, 999))
-      }
+      const { startDate, endDate } = resolveDrePeriod({
+        year,
+        period,
+        date,
+        startDate: inputStartDate,
+        endDate: inputEndDate,
+      })
 
       const isBranchEnterpriseEnum = (e: Enterprise): boolean =>
         e === Enterprise.Box_Filial || e === Enterprise.Cristallux_Filial
@@ -1051,6 +1077,8 @@ export const foodOrderRouter = createTRPCRouter({
       type DreAggRow = {
         groupBy: "enterprise_sector" | "restaurant" | "filial"
         enterprise: string | null
+        empresaId: string | null
+        empresaName: string | null
         sector: string | null
         restaurantId: string | null
         restaurantName: string | null
@@ -1099,6 +1127,13 @@ export const foodOrderRouter = createTRPCRouter({
                   id: true,
                   name: true,
                   code: true,
+                  empresa: {
+                    select: {
+                      id: true,
+                      name: true,
+                      enterprise: true,
+                    },
+                  },
                 },
               },
             },
@@ -1129,20 +1164,26 @@ export const foodOrderRouter = createTRPCRouter({
       orders.forEach((order) => {
         const price = order.menuItem.price
         const effectiveRestaurant = order.restaurant ?? order.menuItem.restaurant
-        const enterprise = order.user.enterprise
+        // Empresa (cadastro novo) derivada da filial do colaborador.
+        const empresa = order.user.filial?.empresa ?? null
+        // Enum efetivo: empresa.enterprise quando há filial; senão o enum legado do usuário.
+        const effectiveEnterprise = empresa?.enterprise ?? order.user.enterprise
         const sector = order.user.setor ?? null
 
         let key: string
         let base: Omit<DreAggRow, "totalOrders" | "totalValue" | "valueFromHeadquartersOrders" | "valueFromBranchOrders">
 
-        const enterpriseEnum = order.user.enterprise
-        const fromBranchOrder = isBranchEnterpriseEnum(enterpriseEnum)
+        const fromBranchOrder = isBranchEnterpriseEnum(effectiveEnterprise)
 
         if (groupBy === "enterprise_sector") {
-          key = `${enterprise}-${sector ?? "sem-setor"}`
+          const empresaId = empresa?.id ?? null
+          // Agrupa pela Empresa nova; registros legados sem filial caem no enum.
+          key = `${empresaId ?? `enum:${effectiveEnterprise}`}-${sector ?? "sem-setor"}`
           base = {
             groupBy: "enterprise_sector",
-            enterprise,
+            enterprise: effectiveEnterprise,
+            empresaId,
+            empresaName: empresa?.name ?? null,
             sector,
             restaurantId: null,
             restaurantName: null,
@@ -1156,6 +1197,8 @@ export const foodOrderRouter = createTRPCRouter({
           base = {
             groupBy: "restaurant",
             enterprise: null,
+            empresaId: null,
+            empresaName: null,
             sector: null,
             restaurantId: effectiveRestaurant?.id ?? null,
             restaurantName: effectiveRestaurant?.name ?? "Não informado",
@@ -1170,6 +1213,8 @@ export const foodOrderRouter = createTRPCRouter({
           base = {
             groupBy: "filial",
             enterprise: null,
+            empresaId: null,
+            empresaName: null,
             sector: null,
             restaurantId: null,
             restaurantName: null,
@@ -1201,8 +1246,10 @@ export const foodOrderRouter = createTRPCRouter({
 
       const dreData = Array.from(dreDataMap.values()).sort((a, b) => {
         if (groupBy === "enterprise_sector") {
-          if ((a.enterprise ?? "") !== (b.enterprise ?? "")) {
-            return (a.enterprise ?? "").localeCompare(b.enterprise ?? "")
+          const aLabel = a.empresaName ?? a.enterprise ?? ""
+          const bLabel = b.empresaName ?? b.enterprise ?? ""
+          if (aLabel !== bLabel) {
+            return aLabel.localeCompare(bLabel)
           }
           return (a.sector ?? "").localeCompare(b.sector ?? "")
         }
@@ -1216,4 +1263,113 @@ export const foodOrderRouter = createTRPCRouter({
 
       return dreData
     }),
-}) 
+
+  // Listar os pedidos individuais que compõem uma linha (empresa + setor) do relatório DRE
+  getEnterpriseSectorOrders: protectedProcedure
+    .input(
+      z.object({
+        year: z.number(),
+        period: z.enum(["month", "quarter", "year"]),
+        date: z.date().optional(),
+        startDate: z.date().optional(),
+        endDate: z.date().optional(),
+        restaurantId: z.string().optional(),
+        // Filtro de filial do relatório (quando aplicado).
+        filialId: z.string().optional(),
+        // Identidade do grupo: empresa (cadastro novo) da linha clicada. Null = grupo legado sem filial.
+        empresaId: z.string().nullable().optional(),
+        // Enum efetivo da linha (usado para casar o grupo legado sem filial).
+        enterprise: z.string(),
+        sector: z.string().nullable(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const caller = await ctx.db.user.findUnique({
+        where: { id: ctx.auth.userId },
+        select: { role_config: true },
+      })
+      const roleConfig = caller?.role_config as RolesConfig | null
+      const canView = roleConfig?.sudo === true || roleConfig?.can_view_dre_report === true
+      if (!canView) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Você não tem permissão para visualizar o relatório DRE",
+        })
+      }
+
+      const { startDate, endDate } = resolveDrePeriod({
+        year: input.year,
+        period: input.period,
+        date: input.date,
+        startDate: input.startDate,
+        endDate: input.endDate,
+      })
+
+      // Reproduz a mesma chave de agrupamento do getDREData (empresa + setor),
+      // garantindo que os pedidos listados batam com os totais da linha.
+      const userFilter: Prisma.UserWhereInput = {
+        setor: input.sector ?? null,
+      }
+      if (input.empresaId) {
+        userFilter.filial = { empresaId: input.empresaId }
+        if (input.filialId) userFilter.filialId = input.filialId
+      } else {
+        // Grupo legado: colaboradores sem filial, casados pelo enum.
+        userFilter.filialId = null
+        userFilter.enterprise = input.enterprise as Enterprise
+      }
+
+      const orders = await ctx.db.foodOrder.findMany({
+        where: {
+          orderDate: { gte: startDate, lte: endDate },
+          status: { not: "CANCELLED" },
+          user: userFilter,
+          ...(input.restaurantId
+            ? {
+                OR: [
+                  { restaurantId: input.restaurantId },
+                  { menuItem: { restaurantId: input.restaurantId } },
+                ],
+              }
+            : {}),
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+              enterprise: true,
+              setor: true,
+              filial: { select: { empresa: { select: { name: true } } } },
+            },
+          },
+          restaurant: { select: { id: true, name: true } },
+          menuItem: {
+            select: {
+              name: true,
+              price: true,
+              restaurant: { select: { id: true, name: true } },
+            },
+          },
+        },
+        orderBy: { orderDate: "desc" },
+      })
+
+      return orders.map((order) => ({
+        id: order.id,
+        userId: order.user.id,
+        userName: `${order.user.firstName ?? ""} ${order.user.lastName ?? ""}`.trim(),
+        email: order.user.email,
+        enterprise: order.user.enterprise,
+        empresaName: order.user.filial?.empresa.name ?? null,
+        sector: order.user.setor ?? null,
+        orderDate: order.orderDate,
+        restaurantName: (order.restaurant ?? order.menuItem.restaurant)?.name ?? null,
+        menuItemName: order.menuItem.name,
+        price: order.menuItem.price,
+        status: order.status,
+      }))
+    }),
+})

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -6,7 +6,7 @@ import { z } from "zod"
 import { type RolesConfig } from "@/types/role-config"
 import { TRPCError } from "@trpc/server"
 import { getEffectiveRoleConfig } from "@/lib/effective-role-config"
-import { ensureFilialConsistentWithEnterprise } from "@/server/validators/filial-enterprise"
+import { resolveEnterpriseFromFilial } from "@/server/validators/filial-enterprise"
 
 
 export const userRouter = createTRPCRouter({
@@ -197,9 +197,10 @@ export const userRouter = createTRPCRouter({
   updateProfile: protectedProcedure
     .input(z.object({
       matricula: z.string().min(1, "Matrícula é obrigatória"),
-      enterprise: z.nativeEnum(Enterprise),
       setor: z.string().min(1, "Setor é obrigatório"),
-      filialId: z.string().nullable(),
+      // Modelo novo: o usuário escolhe Empresa + Filial; gravamos filialId e
+      // derivamos o enum `enterprise` a partir de filial.empresa.
+      filialId: z.string().min(1, "Filial é obrigatória"),
     }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.auth.userId;
@@ -207,10 +208,7 @@ export const userRouter = createTRPCRouter({
         throw new Error("Usuário não autenticado");
       }
 
-      await ensureFilialConsistentWithEnterprise(ctx.db, {
-        filialId: input.filialId,
-        enterprise: input.enterprise,
-      })
+      const enterprise = await resolveEnterpriseFromFilial(ctx.db, input.filialId)
 
       // Primeiro tentar atualizar usuário existente (caso normal em produção)
       try {
@@ -218,7 +216,7 @@ export const userRouter = createTRPCRouter({
           where: { id: userId },
           data: {
             matricula: input.matricula.trim(),
-            enterprise: input.enterprise,
+            enterprise,
             setor: input.setor,
             filialId: input.filialId,
           },
@@ -256,7 +254,7 @@ export const userRouter = createTRPCRouter({
             lastName: null,
             imageUrl: null,
             matricula: input.matricula.trim(),
-            enterprise: input.enterprise,
+            enterprise,
             setor: input.setor,
             filialId: input.filialId,
             role_config: devDefaultRoleConfig,
@@ -611,7 +609,8 @@ export const userRouter = createTRPCRouter({
       emailExtension: z.string().email().optional().or(z.literal("")),
       matricula: z.string().optional().or(z.literal("")),
       email_empresarial: z.string().email().optional().or(z.literal("")),
-      enterprise: z.nativeEnum(Enterprise).optional(),
+      // Modelo novo: empresa é definida pela Filial escolhida; enterprise é derivado.
+      filialId: z.string().nullable().optional(),
       /** Status na empresa: ativo ou desativado. Apenas sudo ou can_manage_dados_basicos_users podem alterar. */
       is_active: z.boolean().optional(),
     }))
@@ -633,7 +632,19 @@ export const userRouter = createTRPCRouter({
         })
       }
 
-      const { userId, ...updateData } = input
+      const { userId, filialId, ...updateData } = input
+
+      // Empresa/Filial: quando filialId é informado, deriva o enum enterprise da
+      // empresa dona da filial. filialId === null desvincula a filial (sem mexer no enum).
+      const companyData: { filialId?: string | null; enterprise?: Enterprise } = {}
+      if (filialId !== undefined) {
+        if (filialId) {
+          companyData.filialId = filialId
+          companyData.enterprise = await resolveEnterpriseFromFilial(ctx.db, filialId)
+        } else {
+          companyData.filialId = null
+        }
+      }
 
       // Se o usuário não é sudo, apenas permitir alterar dados básicos (incluindo is_active)
       if (!effectiveConfig.sudo) {
@@ -647,8 +658,8 @@ export const userRouter = createTRPCRouter({
           emailExtension: input.emailExtension,
           matricula: input.matricula,
           email_empresarial: input.email_empresarial,
-          enterprise: input.enterprise,
           is_active: input.is_active,
+          ...companyData,
         }
 
         return ctx.db.user.update({
@@ -659,7 +670,7 @@ export const userRouter = createTRPCRouter({
 
       return ctx.db.user.update({
         where: { id: userId },
-        data: updateData,
+        data: { ...updateData, ...companyData },
       })
     }),
 
@@ -1051,32 +1062,19 @@ export const userRouter = createTRPCRouter({
         })
       }
 
-      const nextEnterprise = input.enterprise ?? targetUser.enterprise
-      const requiresFilial =
-        nextEnterprise === Enterprise.Box_Filial ||
-        nextEnterprise === Enterprise.Cristallux_Filial
-
-      let nextFilialId =
+      const nextFilialId =
         input.filialId === undefined ? (targetUser.filialId ?? null) : input.filialId
 
-      if (!requiresFilial) {
-        nextFilialId = null
-      } else if (!nextFilialId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Filial é obrigatória para empresas do tipo Filial",
-        })
-      }
-
-      await ensureFilialConsistentWithEnterprise(ctx.db, {
-        filialId: nextFilialId,
-        enterprise: nextEnterprise,
-      })
+      // Modelo novo: com filial definida, o enum enterprise é derivado da empresa
+      // dona da filial. Sem filial, mantém o enum informado (ou o atual).
+      const nextEnterprise = nextFilialId
+        ? await resolveEnterpriseFromFilial(ctx.db, nextFilialId)
+        : (input.enterprise ?? targetUser.enterprise)
 
       return ctx.db.user.update({
         where: { id: input.userId },
         data: {
-          ...(input.enterprise !== undefined ? { enterprise: input.enterprise } : {}),
+          enterprise: nextEnterprise,
           filialId: nextFilialId,
         },
         select: {

--- a/src/server/validators/filial-enterprise.ts
+++ b/src/server/validators/filial-enterprise.ts
@@ -1,37 +1,17 @@
 import { TRPCError } from "@trpc/server"
-import { Enterprise } from "@prisma/client"
-import type { PrismaClient } from "@prisma/client"
-
-export function enterpriseRequiresFilial(enterprise: Enterprise): boolean {
-  return enterprise === Enterprise.Box_Filial || enterprise === Enterprise.Cristallux_Filial
-}
+import type { Enterprise, PrismaClient } from "@prisma/client"
 
 /**
- * Garante que filialId só exista quando a empresa é do tipo Filial e que a filial pertence à mesma empresa.
+ * Modelo novo de vínculo: o usuário é ligado a uma Filial (filialId) e a Empresa
+ * é derivada de `filial.empresa`. O enum legado `enterprise` é mantido em sincronia
+ * com `empresa.enterprise` para compatibilidade com relatórios/exportações antigas.
+ *
+ * Dada uma filial, retorna o enum `enterprise` da empresa dona dela.
  */
-export async function ensureFilialConsistentWithEnterprise(
+export async function resolveEnterpriseFromFilial(
   db: PrismaClient,
-  params: { filialId: string | null; enterprise: Enterprise },
-): Promise<void> {
-  const { filialId, enterprise } = params
-
-  if (!enterpriseRequiresFilial(enterprise)) {
-    if (filialId) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: "Filial só pode ser informada para empresas do tipo Filial (Box Filial ou Cristallux Filial).",
-      })
-    }
-    return
-  }
-
-  if (!filialId) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "Filial é obrigatória para esta empresa.",
-    })
-  }
-
+  filialId: string,
+): Promise<Enterprise> {
   const filial = await db.filial.findUnique({
     where: { id: filialId },
     select: { empresa: { select: { enterprise: true } } },
@@ -44,10 +24,5 @@ export async function ensureFilialConsistentWithEnterprise(
     })
   }
 
-  if (filial.empresa.enterprise !== enterprise) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "A filial selecionada não pertence à empresa do colaborador. Ajuste a empresa ou escolha outra filial.",
-    })
-  }
+  return filial.empresa.enterprise
 }


### PR DESCRIPTION
- DRE: linha de empresa/setor expansível com lista de pessoas (nome, empresa, setor, valor) e botão "Ir para o pedido" (1.30.0)
- Vínculo por Empresa + Filial no onboarding e na tela de Usuários; enterprise derivado/sincronizado no servidor a partir da filial (1.31.0)
- DRE agrupa/exibe pela Empresa cadastrada (nome real) e novo filtro de e-mail dedicado na aba de Pedidos (1.32.0)
- Backfill SQL de filialId para colaboradores Cristallux_Filial

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expandable DRE report rows showing enterprise-sector details with order drill-down
  * Email-based filtering for orders
  * Direct navigation from DRE report to orders with pre-filled filters

* **Improvements**
  * User management and profile setup now use branch (filial) selection for simplified organization
  * Version bumped to 1.32.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->