### PR TITLE
chore: remove notas 1.32/1.33 e descontinua atualização de release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,5 @@ Se a solução:
 Ela é **automaticamente inválida**, mesmo que funcione.
 
 # 14. REGRAS ADICIONAIS
-- Sempre atualize junto o componente de app-relesase-notes-dialog se for Major ou Minor.
-- Quando atualizar o app-release-notes-dialog, não usar termos técnicos e usar termos populares e de fácil compreensão!
+- NÃO atualizar mais as notas de novidades (app-release-notes-dialog / app-release-notes). Por decisão do produto, esse arquivo deixou de ser mantido a cada release. Não adicionar novas entradas nem versões nele.
 - Nunca rodar o Browser sem o usuário explicitamente dizer.

--- a/src/const/app-release-notes.ts
+++ b/src/const/app-release-notes.ts
@@ -1,9 +1,10 @@
 /**
  * Histórico de novidades exibido no diálogo "Novidades" da intranet.
- * Lista apenas marcos **major** (quando existirem) e **minors** com impacto de produto — sem patches.
- * `APP_CURRENT_VERSION` segue o package.json (MMP completo).
+ * NÃO atualizar mais este arquivo a cada release (decisão do produto).
+ * `APP_CURRENT_VERSION` é apenas o rótulo exibido no diálogo e reflete a última
+ * entrada listada abaixo — não precisa acompanhar o package.json.
  */
-export const APP_CURRENT_VERSION = "1.33.0" as const;
+export const APP_CURRENT_VERSION = "1.31.0" as const;
 
 export interface AppReleaseNote {
   /** Versão semântica do marco (minor.0 ou major.0) */
@@ -19,25 +20,6 @@ export interface AppReleaseNote {
  * Incluir somente releases **major** ou **minor** com entrega visível ao usuário.
  */
 export const APP_RELEASE_NOTES: AppReleaseNote[] = [
-  {
-    version: "1.33.0",
-    date: "Junho de 2026",
-    items: [
-      "**Lista de usuários mais prática**: a tela de Usuários agora mostra todo mundo em forma de lista (em vez de cartões grandes), com filtros por setor, empresa, filial e situação (ativos ou desativados). Para editar alguém, é só clicar em **Gerenciar** e abrir a janela com todos os detalhes.",
-      "**Busca que entende acentos**: ao procurar por nome, não precisa se preocupar com acentuação — buscar por \"Maira\" encontra \"Máira\", \"Maíra\" e por aí vai.",
-      "**Histórico de movimentações**: dentro de cada usuário há uma aba **Movimentações** que mostra tudo o que foi alterado no cadastro (dados, permissões, filial, ramal) e quando a pessoa foi desativada ou reativada — com data e quem fez a mudança.",
-      "**Conta desativada sem acesso**: quem está com o cadastro desativado não consegue mais entrar nem visualizar nada na plataforma; ao tentar acessar, vê um aviso explicando a situação.",
-      "**Relatório de almoços mais certo**: no relatório por empresa e setor, cada setor aparece agora em uma única linha por empresa — antes um mesmo setor (como Logística) podia aparecer dividido em duas linhas.",
-    ],
-  },
-  {
-    version: "1.32.0",
-    date: "Junho de 2026",
-    items: [
-      "**DRE mostra a empresa de verdade**: o relatório de resultado passou a exibir o nome da empresa cadastrada (em vez da sigla antiga), deixando os agrupamentos mais claros.",
-      "**Busca por e-mail nos pedidos**: a lista de pedidos ganhou um campo dedicado para buscar pelo e-mail do colaborador, separado da busca por nome.",
-    ],
-  },
   {
     version: "1.31.0",
     date: "Junho de 2026",


### PR DESCRIPTION
- Remove as entradas 1.32.0 e 1.33.0 de app-release-notes
- APP_CURRENT_VERSION passa a refletir a última nota listada (rótulo do diálogo)
- CLAUDE.md (regra 14): não atualizar mais as notas de novidades a cada release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version from 1.33.0 to 1.31.0
  * Adjusted release notes to remove entries for versions 1.33.0 and 1.32.0
  * Updated project documentation regarding release notes maintenance policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->