### PR TITLE
feat(emotion-ruler): libera régua de emoções para todos os usuários

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elo",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/sql/backfill-emotion-ruler-view-all.sql
+++ b/scripts/sql/backfill-emotion-ruler-view-all.sql
@@ -1,0 +1,33 @@
+-- Backfill (OPCIONAL): marca role_config.can_view_emotion_ruler = true
+-- para todos os usuários ativos e não-TOTEM.
+--
+-- Contexto:
+--  * A Régua de Emoções foi liberada para todos os usuários (exceto TOTEM/
+--    desativado) via política centralizada em src/lib/access-control.ts
+--    (canViewEmotionRuler). A visualização NÃO depende mais deste campo.
+--  * Este script é apenas COSMÉTICO: mantém os toggles do editor de permissões
+--    (admin/users) coerentes com o novo comportamento público. Não é necessário
+--    para que a liberação funcione, e cadastros futuros são cobertos pela política,
+--    não por este campo.
+--
+-- Observações de segurança:
+--  * Não toca em usuários TOTEM nem desativados (is_active = false).
+--  * "updatedAt" é setado manualmente porque o @updatedAt do Prisma é aplicado
+--    na camada da aplicação, não em UPDATEs via SQL puro.
+--  * Idempotente: só atualiza quem ainda não tem o campo = true.
+
+-- 1) (Opcional) Conferência antes de aplicar — quantos serão afetados:
+-- SELECT COUNT(*) AS users_a_atualizar
+-- FROM "users"
+-- WHERE "is_active" = true
+--   AND COALESCE(("role_config" ->> 'isTotem')::boolean, false) = false
+--   AND COALESCE(("role_config" ->> 'can_view_emotion_ruler')::boolean, false) = false;
+
+-- 2) Aplicação do backfill:
+UPDATE "users"
+SET "role_config" = COALESCE("role_config", '{}'::jsonb)
+                    || jsonb_build_object('can_view_emotion_ruler', true),
+    "updatedAt"   = NOW()
+WHERE "is_active" = true
+  AND COALESCE(("role_config" ->> 'isTotem')::boolean, false) = false
+  AND COALESCE(("role_config" ->> 'can_view_emotion_ruler')::boolean, false) = false;

--- a/src/hooks/use-access-control.tsx
+++ b/src/hooks/use-access-control.tsx
@@ -189,9 +189,10 @@ export function useAccessControl() {
   };
 
   const canViewEmotionRuler = (): boolean => {
+    // Liberado para todos os usuários, exceto TOTEM/desativado
+    // (alinhado ao helper canViewEmotionRuler em @/lib/access-control).
     if (!db_user?.role_config) return false;
-    if (db_user.role_config.sudo) return true;
-    return db_user.role_config.can_view_emotion_ruler ?? false;
+    return !db_user.role_config.isTotem;
   };
 
   const canManageEmotionRules = (): boolean => {

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -141,12 +141,11 @@ export function canViewCars(roleConfig: RolesConfig | null): boolean {
 }
 
 export function canViewEmotionRuler(roleConfig: RolesConfig | null): boolean {
-  // Régua de Emoções é um módulo restrito (não liberado para todos).
-  // Acesso somente para sudo ou quem tem a permissão explícita; nunca TOTEM/desativado.
+  // Régua de Emoções liberada para todos os usuários, exceto TOTEM/desativado
+  // (alinhado aos demais módulos de visualização). O campo can_view_emotion_ruler
+  // permanece no schema por compatibilidade, mas não restringe mais a visualização.
   if (!roleConfig) return false;
-  if (roleConfig.isTotem) return false;
-  if (roleConfig.sudo) return true;
-  return roleConfig.can_view_emotion_ruler === true;
+  return !roleConfig.isTotem;
 }
 
 /**

--- a/src/server/api/routers/emotion-ruler.ts
+++ b/src/server/api/routers/emotion-ruler.ts
@@ -70,11 +70,8 @@ export const emotionRulerRouter = createTRPCRouter({
 
     const roleConfig = getEffectiveRoleConfig(user);
 
-    if (roleConfig.isTotem === true) {
-      return { shouldShow: false, ruler: null };
-    }
-
-    if (!roleConfig.can_view_emotion_ruler && !roleConfig.sudo) {
+    // Liberado para todos (exceto TOTEM/desativado) via política centralizada.
+    if (!canViewEmotionRuler(roleConfig)) {
       return { shouldShow: false, ruler: null };
     }
 


### PR DESCRIPTION
Régua de Emoções era o único módulo de visualização ainda restrito. Alinha ao padrão dos demais módulos (todos exceto TOTEM/desativado) via política centralizada, cobrindo usuários atuais e futuros sem migração.

- access-control: canViewEmotionRuler retorna !isTotem
- emotion-ruler router (shouldShowModal): usa o helper central
- use-access-control hook: alinhado a !isTotem
- script SQL opcional de backfill (cosmético) do campo can_view_emotion_ruler
- bump de versão 1.37.0 -> 1.38.0 (Minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded access to the Emotion Ruler feature for all users.

* **Chores**
  * Version bumped to 1.38.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->